### PR TITLE
Convert maintainer over to Encore

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,13 @@
 # Change Log
 
+# 0.4.1
+
+- Converted maintainer over to Encore Technologies
+- `api_key` in pack config is now marked with `secure: true` so it will not leak
+  sensitive data.
+  
+  Contributed by Nick Maludy (Encore Technologies)
+
 # 0.4.0
 
 - Migrated to using [python-cloudflare](https://github.com/cloudflare/python-cloudflare)

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -1,4 +1,4 @@
 # Contributors
 
-* Jon Middleton <jon.middleton@pulsant.com>
-* Encore Technologies <code@encore.tech>
+* Encore Technologies <code@encore.tech> [Current Maintainer]
+* Jon Middleton <jon.middleton@pulsant.com> [Original Author]

--- a/config.schema.yaml
+++ b/config.schema.yaml
@@ -3,6 +3,7 @@ api_key:
   type: "string"
   description: "The API Key for the Cloudflare API."
   required: false
+  secret: true
 api_email:
   type: "string"
   description: "The Email address (username) to use with the Cloudflare API."

--- a/pack.yaml
+++ b/pack.yaml
@@ -4,6 +4,6 @@ name: cloudflare
 description: Cloudflare CDN
 keywords:
     - cloudflare
-version: 0.4.0
-author: Jon Middleton
-email: jon.middleton@pulsant.com
+version: 0.4.1
+author: Encore Technologies
+email: code@encore.tech


### PR DESCRIPTION
Converted over maintainer to Encore.

Added `secret: true` to config so sensitive API keys are not leaked. Also, this allows us to store data in key/value store encrypted and not need the `| decrypt_kv` in the Jinja expression within the config.