### PR TITLE
Add action to get/create/delete zone access rule

### DIFF
--- a/actions/create_zone_access_rule.py
+++ b/actions/create_zone_access_rule.py
@@ -1,0 +1,39 @@
+from lib.actions import CloudflareBaseAction
+
+
+class CreateZoneAccessRuleAction(CloudflareBaseAction):
+    def run(self, **kwargs):
+        """
+        Create Access Rule in a Zone
+
+        Args:
+            zone_id: ID of the zone to create the access rule
+            mode: The action the access rule will apply to matched requests
+            target_type: The address type to target in requests
+            target: The address to target in requests
+            notes: An optional note about the rule
+
+        Raises:
+            CloudFlareAPIError: On HTTP Error or Invaild JSON.
+
+        Returns:
+            dict: containing the Access Rule created
+        """
+
+        # grab URL components and remove from kwargs
+        zone_id = kwargs['zone_id']
+        del kwargs['zone_id']
+
+        # set up target configuration
+        target_config = {
+                'target': kwargs['target_type'],
+                'value': kwargs['target']
+        }
+        del kwargs['target_type']
+        del kwargs['target']
+        kwargs['configuration'] = target_config
+
+        # invoke API call
+        func = self.client.zones.firewall.access_rules.rules.post  # pylint: disable=no-member
+        result = self.invoke(func, zone_id, **kwargs)
+        return result

--- a/actions/create_zone_access_rule.yaml
+++ b/actions/create_zone_access_rule.yaml
@@ -1,0 +1,39 @@
+---
+description: "Create an access rule for a zone"
+enabled: true
+entry_point: "create_zone_access_rule.py"
+name: "create_zone_access_rule"
+pack: "cloudflare"
+runner_type: "python-script"
+parameters:
+  zone_id:
+    type: string
+    description: "Zone identify tag (ex: '023e105f4ecef8ad9ca31a8372d0c353')"
+    required: true
+  mode:
+    type: string
+    description: "The action to apply to a matched request"
+    required: true
+    enum:
+      - "block"
+      - "challenge"
+      - "js_challenge"
+      - "managed_challenge"
+      - "whitelist"
+  target_type:
+    type: string
+    description: "The address type to target in requests"
+    required: true
+    enum:
+      - "asn"
+      - "country"
+      - "ip_range"
+      - "ip"
+      - "ip6"
+  target:
+    type: string
+    description: "The address to target in requests"
+    required: true
+  notes:
+    type: string
+    description: "A note about the rule."

--- a/actions/delete_zone_access_rule.py
+++ b/actions/delete_zone_access_rule.py
@@ -1,0 +1,30 @@
+from lib.actions import CloudflareBaseAction
+
+
+class DeleteZoneAccessRuleAction(CloudflareBaseAction):
+    def run(self, **kwargs):
+        """
+        Delete Access Rule in a Zone
+
+        Args:
+            zone_id: ID of the zone to delete from the access rule
+            rule_id: ID of the rule to delete
+
+        Raises:
+            CloudFlareAPIError: On HTTP Error or Invaild JSON.
+
+        Returns:
+            dict: containing the Access Rule deleted
+        """
+
+        # grab URL components and remove from kwargs
+        zone_id = kwargs['zone_id']
+        del kwargs['zone_id']
+
+        rule_id = kwargs['rule_id']
+        del kwargs['rule_id']
+
+        # invoke API call
+        func = self.client.zones.firewall.access_rules.rules.delete  # pylint: disable=no-member
+        result = self.invoke(func, zone_id, rule_id, **kwargs)
+        return result

--- a/actions/delete_zone_access_rule.yaml
+++ b/actions/delete_zone_access_rule.yaml
@@ -1,0 +1,16 @@
+---
+description: "Delete an access rule from a zone"
+enabled: true
+entry_point: "delete_zone_access_rule.py"
+name: "delete_zone_access_rule"
+pack: "cloudflare"
+runner_type: "python-script"
+parameters:
+  zone_id:
+    type: string
+    description: "Zone identify tag (ex: '023e105f4ecef8ad9ca31a8372d0c353')"
+    required: true
+  rule_id:
+    type: string
+    description: "Rule identify tag (ex: '023e105f4ecef8ad9ca31a8372d0c353')"
+    required: true

--- a/actions/get_zone_access_rule.py
+++ b/actions/get_zone_access_rule.py
@@ -1,0 +1,34 @@
+from lib.actions import CloudflareBaseAction
+
+
+class GetZoneAccessRuleAction(CloudflareBaseAction):
+    def run(self, **kwargs):
+        """
+        List Access Rule in a Zone
+
+        Args:
+            zone_id: ID of the zone to delete from the access rule
+
+        Raises:
+            CloudFlareAPIError: On HTTP Error or Invaild JSON.
+
+        Returns:
+            list: containing the Access Rules
+        """
+
+        # grab URL components and remove from kwargs
+        zone_id = kwargs['zone_id']
+        del kwargs['zone_id']
+
+        if 'configuration_target' in kwargs:
+            kwargs['configuration.target'] = kwargs['configuration_target']
+            del kwargs['configuration_target']
+
+        if 'configuration_value' in kwargs:
+            kwargs['configuration.value'] = kwargs['configuration_value']
+            del kwargs['configuration_value']
+
+        # invoke API call
+        func = self.client.zones.firewall.access_rules.rules.get  # pylint: disable=no-member
+        result = self.invoke(func, zone_id, **kwargs)
+        return result

--- a/actions/get_zone_access_rule.yaml
+++ b/actions/get_zone_access_rule.yaml
@@ -1,0 +1,35 @@
+---
+description: "List access rules from a zone"
+enabled: true
+entry_point: "get_zone_access_rule.py"
+name: "get_zone_access_rule"
+pack: "cloudflare"
+runner_type: "python-script"
+parameters:
+  zone_id:
+    type: string
+    description: "Zone identify tag (ex: '023e105f4ecef8ad9ca31a8372d0c353')"
+    required: true
+  match:
+    type: string
+    description: "Whether to match all search requirements or at least one (any)."
+    enum:
+      - "all"
+      - "any"
+  notes:
+    type: string
+    description: "Search rules by notes."
+  mode:
+    type: string
+    description: "Search rules by action."
+  configuration_target:
+    type: string
+    description: "Search rules by target."
+    enum:
+      - "asn"
+      - "country"
+      - "ip"
+      - "ip_range"
+  configuration_value:
+    type: string
+    description: "Search rules by IP, range, or country code"

--- a/actions/lib/actions.py
+++ b/actions/lib/actions.py
@@ -55,8 +55,11 @@ class CloudflareBaseAction(Action):
                 # NOTE: the default page number = 1
                 params['page'] = page_number
 
-            # invoke the Cloudflare APIo
-            raw_results = func(*args, params=copy.deepcopy(params))
+            # invoke the Cloudflare API
+            if func.__name__ == 'post':
+                raw_results = func(*args, data=copy.deepcopy(params))
+            else:
+                raw_results = func(*args, params=copy.deepcopy(params))
 
             # do we have paged results
             if 'result_info' not in raw_results:


### PR DESCRIPTION
This PR add 3 new action:
* `create_zone_access_rule` - create a firewall access rule for a zone
* `delete_zone_access_rule`- delete a firewall access rule from a zone
* `get_zone_access_rule` - list/search firewall access rule in a zone

Also, it adjusts `lib/actions.py` to allow do POST requests.