### PR TITLE
hotfix/fix-ci-errors

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # Change Log
 
+# 1.0.1
+
+- Updated files to work with latest CI updates
+
 # 1.0.0
 
 - Fixed mocks for tests

--- a/pack.yaml
+++ b/pack.yaml
@@ -4,7 +4,7 @@ name: cloudflare
 description: Cloudflare CDN
 keywords:
     - cloudflare
-version: 1.0.0
+version: 1.0.1
 python_versions:
   - "3"
 author: Encore Technologies

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-cloudflare
+git+https://github.com/cloudflare/python-cloudflare.git@2.9.12
 six

--- a/tests/test_action_base.py
+++ b/tests/test_action_base.py
@@ -15,17 +15,17 @@ class BaseActionTestCase(CloudflareBaseActionTestCase):
 
     def test_init_blank(self):
         action = self.get_action_instance(self.config_blank)
-        self.assertEquals(action.api_key, None)
-        self.assertEquals(action.api_email, None)
-        self.assertEquals(action.client._base.token, None)
-        self.assertEquals(action.client._base.email, None)
+        self.assertEqual(action.api_key, None)
+        self.assertEqual(action.api_email, None)
+        self.assertEqual(action.client._base.token, None)
+        self.assertEqual(action.client._base.email, None)
 
     def test_init_good(self):
         action = self.get_action_instance(self.config_good)
-        self.assertEquals(action.api_key, "API-Key")
-        self.assertEquals(action.api_email, "user@domain.tld")
-        self.assertEquals(action.client._base.token, "API-Key")
-        self.assertEquals(action.client._base.email, "user@domain.tld")
+        self.assertEqual(action.api_key, "API-Key")
+        self.assertEqual(action.api_email, "user@domain.tld")
+        self.assertEqual(action.client._base.token, "API-Key")
+        self.assertEqual(action.client._base.email, "user@domain.tld")
 
     def test_kwargs_to_params(self):
         action = self.get_action_instance({})
@@ -39,10 +39,10 @@ class BaseActionTestCase(CloudflareBaseActionTestCase):
         result = action.kwargs_to_params(**kwargs_dict)
 
         # assert
-        self.assertEquals(result, {"test_std": "value1",
-                                   "test_list": [],
-                                   "test_dict": {},
-                                   "test_int": 1})
+        self.assertEqual(result, {"test_std": "value1",
+                                  "test_list": [],
+                                  "test_dict": {},
+                                  "test_int": 1})
 
     def test_invoke_paging(self):
         action = self.get_action_instance({})
@@ -79,7 +79,7 @@ class BaseActionTestCase(CloudflareBaseActionTestCase):
         result = action.invoke(mock_func, "zone_id", **params)
 
         # asserts
-        self.assertEquals(result, [1, 2, 3, 4, 5, 6, 7, 8, 9])
+        self.assertEqual(result, [1, 2, 3, 4, 5, 6, 7, 8, 9])
 
         # ensure we called with the proper page numbers, in the proper order
         expected_calls = [
@@ -118,7 +118,7 @@ class BaseActionTestCase(CloudflareBaseActionTestCase):
         result = action.invoke(mock_func, "arg", **params)
 
         # asserts
-        self.assertEquals(result, [1, 2, 3])
+        self.assertEqual(result, [1, 2, 3])
 
         # ensure we called with the no page number
         expected_calls = [
@@ -141,7 +141,7 @@ class BaseActionTestCase(CloudflareBaseActionTestCase):
         result = action.invoke(mock_func, "zone_id", **params)
 
         # asserts
-        self.assertEquals(result, [1, 2, 3])
+        self.assertEqual(result, [1, 2, 3])
 
         # ensure we called with no page number
         expected_calls = [


### PR DESCRIPTION
Fixed files to work with latest CI updates:

- assertEquals has been deprecated since python 2.7 and replaced with assertEqual
- pinned cloudflare to github link and 2.9.12 tag
    - this link is to an archived repo (on Nov 21, 2024) that has been moved to a new one
    - it needs to be the old github link because the new module has the same name
    - the old repos highest tag is 2.20.0 but that was causing unit test errors and the highest version that didn't have any errors was 2.9.12

  
This will need to be updated in the future to work with the new cloudflare-python repo
- https://github.com/cloudflare/cloudflare-python
- the new repo works with python 3.8+
- Issue created here: https://github.com/StackStorm-Exchange/stackstorm-cloudflare/issues/13

